### PR TITLE
Implement Log Level filter

### DIFF
--- a/Opserver.Core/Data/Exceptions/ExceptionSorts.cs
+++ b/Opserver.Core/Data/Exceptions/ExceptionSorts.cs
@@ -19,6 +19,8 @@
         MachineNameAsc = 14,
         MachineNameDesc = 15,
         CountAsc = 16,
-        CountDesc = 17
+        CountDesc = 17,
+        LevelAsc = 18,
+        LevelDesc = 19
     }
 }

--- a/Opserver.Core/Data/Exceptions/ExceptionStore.cs
+++ b/Opserver.Core/Data/Exceptions/ExceptionStore.cs
@@ -171,6 +171,7 @@ Select ApplicationName as Name,
             public Guid? StartAt { get; set; }
             public ExceptionSorts Sort { get; set; }
             public Guid? Id { get; set; }
+            public HashSet<ExceptionLogLevel> LogLevels { get; set; } = new HashSet<ExceptionLogLevel>();
 
             public override int GetHashCode()
             {
@@ -185,6 +186,7 @@ Select ApplicationName as Name,
                 hashCode = (hashCode * -1521134295) + EqualityComparer<DateTime?>.Default.GetHashCode(EndDate);
                 hashCode = (hashCode * -1521134295) + EqualityComparer<Guid?>.Default.GetHashCode(StartAt);
                 hashCode = (hashCode * -1521134295) + EqualityComparer<Guid?>.Default.GetHashCode(Id);
+                hashCode = (hashCode * -1521134295) + EqualityComparer<HashSet<ExceptionLogLevel>>.Default.GetHashCode(LogLevels);
                 return (hashCode * -1521134295) + Sort.GetHashCode();
             }
         }
@@ -226,6 +228,7 @@ Select e.Id,
 	   e.ErrorHash,
 	   e.DuplicateCount,
 	   e.DeletionDate,
+       e.LogLevel,
 	   ROW_NUMBER() Over(").Append(GetSortString(search.Sort)).Append(@") rowNum
   From ").Append(TableName).AppendLine(" e");
 
@@ -257,6 +260,10 @@ Select e.Id,
             if (search.Id.HasValue)
             {
                 AddClause("Id = @Id");
+            }
+            if (search.LogLevels.Count > 0)
+            {
+                AddClause(string.Join(" OR ", search.LogLevels.Select(logLevel => "LogLevel = " + (short) logLevel)));
             }
             if (mode == QueryMode.Delete)
             {
@@ -356,6 +363,10 @@ Select e.Id,
                     return " Order By IsNull(DuplicateCount, 1) Desc, CreationDate Desc";
                 case ExceptionSorts.TimeAsc:
                     return " Order By CreationDate";
+                case ExceptionSorts.LevelAsc:
+                    return " Order By LogLevel, CreationDate Desc";
+                case ExceptionSorts.LevelDesc:
+                    return " Order By LogLevel Desc, CreationDate Desc ";
                 //case ExceptionSorts.TimeDesc:
                 default:
                     return " Order By CreationDate Desc";

--- a/Opserver/Content/js/Scripts.js
+++ b/Opserver/Content/js/Scripts.js
@@ -1438,6 +1438,21 @@ Status.Exceptions = (function () {
 
     }
 
+    function getSelectedLogLevels() {
+        return $('#logLevelFilter input:checked')
+            .map(function (index, element) { return element.value; })
+            .get();
+    }
+
+    $(document).on('submit', '#exceptionFiltersForm', function (event) {
+        let selectedLogLevels = getSelectedLogLevels();
+        let searchParams = new URLSearchParams(window.location.search);
+        searchParams.set("logLevels", selectedLogLevels.join(','));
+        let urlWithoutSearchParams = window.location.href.split('?')[0];
+        location.href = urlWithoutSearchParams + '?' + searchParams.toString();
+        event.preventDefault();
+    });
+
     return {
         init: init
     };

--- a/Opserver/Content/js/Scripts.js
+++ b/Opserver/Content/js/Scripts.js
@@ -1053,7 +1053,8 @@ Status.Exceptions = (function () {
             store: options.store,
             group: options.group,
             log: options.log,
-            sort: options.sort
+            sort: options.sort,
+            logLevels: options.logLevels
         };
 
         // TODO: Set refresh params

--- a/Opserver/Controllers/ExceptionsController.cs
+++ b/Opserver/Controllers/ExceptionsController.cs
@@ -34,7 +34,7 @@ namespace StackExchange.Opserver.Controllers
         private Guid? CurrentId;
         private Guid? CurrentSimilarId;
         private ExceptionSorts CurrentSort;
-        private HashSet<ExceptionLogLevel> CurrentExceptionLogLevels = new HashSet<ExceptionLogLevel>() { ExceptionLogLevel.Critical, ExceptionLogLevel.Error };
+        private HashSet<ExceptionLogLevel> CurrentExceptionLogLevels;
         private static readonly HashSet<ExceptionLogLevel> DefaultExceptionLogLevels = new HashSet<ExceptionLogLevel>() { ExceptionLogLevel.Critical, ExceptionLogLevel.Error };
 
         protected override void OnActionExecuting(ActionExecutingContext filterContext)

--- a/Opserver/Views/Exceptions/Exceptions.Detail.cshtml
+++ b/Opserver/Views/Exceptions/Exceptions.Detail.cshtml
@@ -18,7 +18,7 @@
         <script>
             var Exception = @json.AsHtml();
             $(function () {
-                Status.Exceptions.init({ store: @Model.Store.Name.ToJson(), group: @(Model.Group?.Name.ToJson()), log: @error.ApplicationName.ToJson(), id: '@error.GUID.ToString()' });
+                Status.Exceptions.init({ store: @Model.Store.Name.ToJson(), group: @(Model.Group?.Name.ToJson()), log: @error.ApplicationName.ToJson(), id: '@error.GUID.ToString()', logLevels = @(Model.CommaJoinedSelectedLogLevels()) });
             });
         </script>
     }

--- a/Opserver/Views/Exceptions/Exceptions.Filters.cshtml
+++ b/Opserver/Views/Exceptions/Exceptions.Filters.cshtml
@@ -1,4 +1,6 @@
-﻿<form class="navbar-form">
+﻿@model StackExchange.Opserver.Views.Exceptions.ExceptionsModel
+
+<form class="navbar-form" id="exceptionFiltersForm">
     <div class="form-group">
         <div class="dropdown">
             <button class="btn btn-xs btn-default dropdown-toggle" type="button" id="logLevelDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
@@ -6,30 +8,17 @@
                 <span class="caret"></span>
             </button>
             <ul class="dropdown-menu" aria-labelledby="logLevelDropdown" id="logLevelFilter">
-                <li>
-                    <input class="form-check-input" type="checkbox" id="criticalLogLevelCheckbox" value="critical">
-                    <label class="form-check-label" for="inlineCheckbox1">Critical</label>
-                </li>
-                <li>
-                    <input class="form-check-input" type="checkbox" id="errorLogLevelCheckbox" value="error">
-                    <label class="form-check-label" for="inlineCheckbox2">Error</label>
-                </li>
-                <li>
-                    <input class="form-check-input" type="checkbox" id="warningLogLevelCheckbox" value="warning">
-                    <label class="form-check-label" for="inlineCheckbox3">Warning</label>
-                </li>
-                <li>
-                    <input class="form-check-input" type="checkbox" id="infoLogLevelCheckbox" value="info">
-                    <label class="form-check-label" for="inlineCheckbox4">Info</label>
-                </li>
-                <li>
-                    <input class="form-check-input" type="checkbox" id="debugLogLevelCheckbox" value="debug">
-                    <label class="form-check-label" for="inlineCheckbox5">Debug</label>
-                </li>
-                <li>
-                    <input class="form-check-input" type="checkbox" id="traceLogLevelCheckbox" value="trace">
-                    <label class="form-check-label" for="inlineCheckbox6">Trace</label>
-                </li>
+                @foreach (var logLevel in Model.LogLevels)
+                {
+                    <li>
+                        @{ 
+                            string logLevelCheckboxId = logLevel.GetName() + "LogLevelCheckbox";
+                            bool logLevelChecked = Model.SelectedLogLevels.Contains(logLevel);
+                        }
+                        <input class="form-check-input" type="checkbox" id="@logLevelCheckboxId" value="@logLevel.GetName()" @(logLevelChecked ? "checked" : "")>
+                        <label class="form-check-label" for="@logLevelCheckboxId">@logLevel.GetName()</label>
+                    </li>
+                }
             </ul>
         </div>
     </div>

--- a/Opserver/Views/Exceptions/Exceptions.Model.cs
+++ b/Opserver/Views/Exceptions/Exceptions.Model.cs
@@ -3,6 +3,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Web;
 using StackExchange.Exceptional;
+using StackExchange.Opserver.Controllers;
 using StackExchange.Opserver.Data.Exceptions;
 
 namespace StackExchange.Opserver.Views.Exceptions
@@ -22,6 +23,9 @@ namespace StackExchange.Opserver.Views.Exceptions
         public ExceptionStore.SearchParams SearchParams { get; set; }
         public Error Exception { get; set; }
         public List<Error> Errors { get; set; }
+
+        public List<ExceptionLogLevel> LogLevels = new List<ExceptionLogLevel>() { ExceptionLogLevel.Critical, ExceptionLogLevel.Error, ExceptionLogLevel.Warning, ExceptionLogLevel.Info, ExceptionLogLevel.Debug, ExceptionLogLevel.Trace };
+        public HashSet<ExceptionLogLevel> SelectedLogLevels { get; set; } = new HashSet<ExceptionLogLevel>();
 
         public bool ShowAll => Group == null && Log == null;
         private int? _shownCount;
@@ -80,6 +84,11 @@ namespace StackExchange.Opserver.Views.Exceptions
                 if (Log != null) result["log"] = Log.Name;
                 return result;
             }
+        }
+
+        public string CommaJoinedSelectedLogLevels()
+        {
+            return string.Join(",", SelectedLogLevels.Select(logLevel => logLevel.ToString()));
         }
     }
 }

--- a/Opserver/Views/Exceptions/Exceptions.Navigation.cshtml
+++ b/Opserver/Views/Exceptions/Exceptions.Navigation.cshtml
@@ -5,7 +5,7 @@
 }
 @if (Model.Groups.Count > 1)
 {
-    <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name })" title="View All" class="btn btn-xs@(Model.ShowAll ? " btn-primary" : null)">View All</a>
+    <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name, logLevels = Model.CommaJoinedSelectedLogLevels() })" title="View All" class="btn btn-xs@(Model.ShowAll ? " btn-primary" : null)">View All</a>
 }
 @foreach (var g in Model.Groups)
 {
@@ -17,7 +17,7 @@
     var btnClass = active ? "btn-primary" : "";
     var app = Model.Log != null && g.Applications.Contains(Model.Log) ? Model.Log : null;
     <div class="btn-group dropdown">
-        <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name, group = g.Name })" class="btn btn-xs @btnClass">
+        <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name, group = g.Name, logLevels = Model.CommaJoinedSelectedLogLevels() })" class="btn btn-xs @btnClass">
             @g.Name
             @if (app != null)
             {
@@ -36,7 +36,7 @@
             @foreach (var a in g.Applications)
                 {
                 <li class="@(Model.Log?.Name == a.Name || g.Applications.Count == 1 ? " active" : null)">
-                    <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name, group = g.Name, log = a.Name })">
+                    <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name, group = g.Name, log = a.Name, logLevels = Model.CommaJoinedSelectedLogLevels()})">
                         @a.Name
                         <span class="badge js-exception-total" data-name="@g.Name-@a.Name">@a.ExceptionCount.ToComma()</span>
                     </a>

--- a/Opserver/Views/Exceptions/Exceptions.Table.Rows.cshtml
+++ b/Opserver/Views/Exceptions/Exceptions.Table.Rows.cshtml
@@ -58,6 +58,7 @@
                 <a href="~/exceptions?log=@e.ApplicationName.UrlEncode()&store=@Model.Store.Name.UrlEncode()">@e.ApplicationName</a>
             }
         </td>
+        <td>@e.ExceptionLevel().GetName()</td>
         <td>
             <a class="text-wordbreak js-exception-link @(e.Message.StartsWith("Failed to retrieve error log:") ? "bad-error" : null)" href="~/exceptions/detail?id=@e.GUID&log=@e.ApplicationName.UrlEncode()&store=@Model.Store.Name.UrlEncode()">
                 @(e.Message.TruncateWithEllipsis(110))

--- a/Opserver/Views/Exceptions/Exceptions.Table.cshtml
+++ b/Opserver/Views/Exceptions/Exceptions.Table.cshtml
@@ -34,6 +34,7 @@
                 <th class="@(showActions ? "" : "hidden")"></th>
                 <th>@HeaderLink("Time", ExceptionSorts.TimeDesc)</th>
                 <th>@(Model.Log != null ? HeaderLink("Type", ExceptionSorts.TypeAsc) : HeaderLink("App", ExceptionSorts.AppAsc))</th>
+                <th>@HeaderLink("Level", ExceptionSorts.LevelDesc)</th>
                 <th>@HeaderLink("Error", ExceptionSorts.MessageAsc)</th>
                 <th>@HeaderLink("Url", ExceptionSorts.UrlAsc)</th>
                 <th>@HeaderLink("Remote IP", ExceptionSorts.IPAddressAsc)</th>

--- a/Opserver/Views/Exceptions/Exceptions.cshtml
+++ b/Opserver/Views/Exceptions/Exceptions.cshtml
@@ -26,7 +26,8 @@
                 loadMore: @(Model.LoadAsyncSize),
                 enablePreviews: @Current.Settings.Exceptions.EnablePreviews.ToJson(),
                 showDeleted: @Model.ShowDeleted.ToJson(),
-                search: @Model.Search.ToJson()
+                search: @Model.Search.ToJson(),
+                logLevels: '@Model.CommaJoinedSelectedLogLevels()'
             });
         });
     </script>


### PR DESCRIPTION
* Implemented Log Level filter
* Behaviour of the filter (that I also tested):
  * The default Log Level filter is set to Critical and Error (these are the values used when the use has not explicitly set a value for it)
  * If the search box is used then the Log Level filter is set to any level, the user can later re-apply the filter. I did this to avoid hiding potential results when a search query is performed
  * Any combination of log level filter works
  * Selecting all levels or none have the same behaviour, all logs are shown
  * The LoadMore functionality uses the Log Levels as well
* On my local setup I've created two local nuget packages for Exceptional and Exceptional.Shared, and set the project to use them, that's why I can reference the new changes made on our Exceptional repo