### PR TITLE
Implement Url and Host filters

### DIFF
--- a/Opserver.Core/Data/Exceptions/ExceptionStore.cs
+++ b/Opserver.Core/Data/Exceptions/ExceptionStore.cs
@@ -172,6 +172,8 @@ Select ApplicationName as Name,
             public ExceptionSorts Sort { get; set; }
             public Guid? Id { get; set; }
             public HashSet<ExceptionLogLevel> LogLevels { get; set; } = new HashSet<ExceptionLogLevel>();
+            public string SimilarHost { get; set; }
+            public string SimilarUrl { get; set; }
 
             public override int GetHashCode()
             {
@@ -187,6 +189,8 @@ Select ApplicationName as Name,
                 hashCode = (hashCode * -1521134295) + EqualityComparer<Guid?>.Default.GetHashCode(StartAt);
                 hashCode = (hashCode * -1521134295) + EqualityComparer<Guid?>.Default.GetHashCode(Id);
                 hashCode = (hashCode * -1521134295) + EqualityComparer<HashSet<ExceptionLogLevel>>.Default.GetHashCode(LogLevels);
+                hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(SimilarHost);
+                hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(SimilarUrl);
                 return (hashCode * -1521134295) + Sort.GetHashCode();
             }
         }
@@ -263,7 +267,15 @@ Select e.Id,
             }
             if (search.LogLevels.Count > 0)
             {
-                AddClause(string.Join(" OR ", search.LogLevels.Select(logLevel => "LogLevel = " + (short) logLevel)));
+                AddClause("(" + string.Join(" OR ", search.LogLevels.Select(logLevel => "LogLevel = " + (short) logLevel)) + ")");
+            }
+            if (search.SimilarHost.HasValue())
+            {
+                AddClause("Host Like @SimilarHost");
+            }
+            if (search.SimilarUrl.HasValue())
+            {
+                AddClause("Url Like @SimilarUrl");
             }
             if (mode == QueryMode.Delete)
             {
@@ -300,7 +312,9 @@ Select e.Id,
                 query = "%" + search.SearchQuery + "%",
                 search.StartAt,
                 search.Count,
-                search.Id
+                search.Id,
+                SimilarHost = "%" + search.SimilarHost + "%",
+                SimilarUrl = "%" + search.SimilarUrl + "%"
             });
         }
 

--- a/Opserver/Content/js/Scripts.js
+++ b/Opserver/Content/js/Scripts.js
@@ -1054,7 +1054,9 @@ Status.Exceptions = (function () {
             group: options.group,
             log: options.log,
             sort: options.sort,
-            logLevels: options.logLevels
+            logLevels: options.logLevels,
+            similarHost: options.similarHost,
+            similarUrl: options.similarUrl
         };
 
         // TODO: Set refresh params
@@ -1445,12 +1447,41 @@ Status.Exceptions = (function () {
             .get();
     }
 
+    function getHostFilterValue() {
+        return $('#hostFilterInput').val();
+    }
+
+    function getUrlFilterValue() {
+        return $('#urlFilterInput').val();
+    }
+
     $(document).on('submit', '#exceptionFiltersForm', function (event) {
-        let selectedLogLevels = getSelectedLogLevels();
         let searchParams = new URLSearchParams(window.location.search);
-        searchParams.set("logLevels", selectedLogLevels.join(','));
+        let selectedLogLevels = getSelectedLogLevels();
+        if (selectedLogLevels.length === 0) {
+            searchParams.delete("logLevels");
+        } else {
+            searchParams.set("logLevels", selectedLogLevels.join(','));
+        }
+        let host = getHostFilterValue();
+        if (host === null || host === '') {
+            searchParams.delete("similarHost");
+        } else {
+            searchParams.set("similarHost", host);
+        }
+        let url = getUrlFilterValue();
+        if (url === null || url === '') {
+            searchParams.delete("similarUrl");
+        } else {
+            searchParams.set("similarUrl", url);
+        }
+
         let urlWithoutSearchParams = window.location.href.split('?')[0];
-        location.href = urlWithoutSearchParams + '?' + searchParams.toString();
+        if (searchParams === null || searchParams.toString() === '') {
+            location.href = urlWithoutSearchParams;
+        } else {
+            location.href = urlWithoutSearchParams + '?' + searchParams.toString();
+        }
         event.preventDefault();
     });
 

--- a/Opserver/Controllers/ExceptionsController.cs
+++ b/Opserver/Controllers/ExceptionsController.cs
@@ -36,6 +36,8 @@ namespace StackExchange.Opserver.Controllers
         private ExceptionSorts CurrentSort;
         private HashSet<ExceptionLogLevel> CurrentExceptionLogLevels;
         private static readonly HashSet<ExceptionLogLevel> DefaultExceptionLogLevels = new HashSet<ExceptionLogLevel>() { ExceptionLogLevel.Critical, ExceptionLogLevel.Error };
+        private string CurrentSimilarHost;
+        private string CurrentSimilarUrl;
 
         protected override void OnActionExecuting(ActionExecutingContext filterContext)
         {
@@ -46,6 +48,8 @@ namespace StackExchange.Opserver.Controllers
             CurrentSimilarId = Request.Params["similar"].HasValue() && Guid.TryParse(Request.Params["similar"], out var similarGuid) ? similarGuid : (Guid?)null;
             Enum.TryParse(Request.Params["sort"], out CurrentSort);
             CurrentExceptionLogLevels = GetCurrentExceptionLogLevels(Request);
+            CurrentSimilarHost = Request.Params["similarHost"];
+            CurrentSimilarUrl = Request.Params["similarUrl"];
 
             if (CurrentLog.HasValue())
             {
@@ -105,7 +109,9 @@ namespace StackExchange.Opserver.Controllers
                 Log = CurrentLog,
                 Sort = CurrentSort,
                 Id = CurrentId,
-                LogLevels = CurrentExceptionLogLevels
+                LogLevels = CurrentExceptionLogLevels,
+                SimilarHost = CurrentSimilarHost,
+                SimilarUrl = CurrentSimilarUrl
             };
 
             if (Request.Params["q"].HasValue())
@@ -146,7 +152,9 @@ namespace StackExchange.Opserver.Controllers
                 Log = log,
                 Sort = CurrentSort,
                 Errors = errors,
-                SelectedLogLevels = CurrentExceptionLogLevels
+                SelectedLogLevels = CurrentExceptionLogLevels,
+                SimilarHost = CurrentSimilarHost,
+                SimilarUrl = CurrentSimilarUrl
             };
         }
 

--- a/Opserver/Views/Exceptions/Exceptions.Detail.cshtml
+++ b/Opserver/Views/Exceptions/Exceptions.Detail.cshtml
@@ -18,7 +18,7 @@
         <script>
             var Exception = @json.AsHtml();
             $(function () {
-                Status.Exceptions.init({ store: @Model.Store.Name.ToJson(), group: @(Model.Group?.Name.ToJson()), log: @error.ApplicationName.ToJson(), id: '@error.GUID.ToString()', logLevels = @(Model.CommaJoinedSelectedLogLevels()) });
+                Status.Exceptions.init({ store: @Model.Store.Name.ToJson(), group: @(Model.Group?.Name.ToJson()), log: @error.ApplicationName.ToJson(), id: '@error.GUID.ToString()'});
             });
         </script>
     }

--- a/Opserver/Views/Exceptions/Exceptions.Filters.cshtml
+++ b/Opserver/Views/Exceptions/Exceptions.Filters.cshtml
@@ -2,6 +2,12 @@
 
 <form class="navbar-form" id="exceptionFiltersForm">
     <div class="form-group">
+        <input id="hostFilterInput" type="text" class="form-control input-sm" placeholder="Filter by Host" value="@(Model.SimilarHost == null ? "" : Model.SimilarHost)">
+    </div>
+    <div class="form-group">
+        <input id="urlFilterInput" type="text" class="form-control input-sm" placeholder="Filter by Url" value="@(Model.SimilarUrl == null ? "" : Model.SimilarUrl)">
+    </div>
+    <div class="form-group">
         <div class="dropdown">
             <button class="btn btn-xs btn-default dropdown-toggle" type="button" id="logLevelDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                 Log Level
@@ -11,7 +17,7 @@
                 @foreach (var logLevel in Model.LogLevels)
                 {
                     <li>
-                        @{ 
+                        @{
                             string logLevelCheckboxId = logLevel.GetName() + "LogLevelCheckbox";
                             bool logLevelChecked = Model.SelectedLogLevels.Contains(logLevel);
                         }

--- a/Opserver/Views/Exceptions/Exceptions.Model.cs
+++ b/Opserver/Views/Exceptions/Exceptions.Model.cs
@@ -26,6 +26,8 @@ namespace StackExchange.Opserver.Views.Exceptions
 
         public List<ExceptionLogLevel> LogLevels = new List<ExceptionLogLevel>() { ExceptionLogLevel.Critical, ExceptionLogLevel.Error, ExceptionLogLevel.Warning, ExceptionLogLevel.Info, ExceptionLogLevel.Debug, ExceptionLogLevel.Trace };
         public HashSet<ExceptionLogLevel> SelectedLogLevels { get; set; } = new HashSet<ExceptionLogLevel>();
+        public string SimilarHost { get; set; }
+        public string SimilarUrl { get; set; }
 
         public bool ShowAll => Group == null && Log == null;
         private int? _shownCount;

--- a/Opserver/Views/Exceptions/Exceptions.Navigation.cshtml
+++ b/Opserver/Views/Exceptions/Exceptions.Navigation.cshtml
@@ -5,7 +5,7 @@
 }
 @if (Model.Groups.Count > 1)
 {
-    <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name, logLevels = Model.CommaJoinedSelectedLogLevels() })" title="View All" class="btn btn-xs@(Model.ShowAll ? " btn-primary" : null)">View All</a>
+    <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name, logLevels = Model.CommaJoinedSelectedLogLevels(), similarHost = Model.SimilarHost, similarUrl = Model.SimilarUrl })" title="View All" class="btn btn-xs@(Model.ShowAll ? " btn-primary" : null)">View All</a>
 }
 @foreach (var g in Model.Groups)
 {
@@ -17,7 +17,7 @@
     var btnClass = active ? "btn-primary" : "";
     var app = Model.Log != null && g.Applications.Contains(Model.Log) ? Model.Log : null;
     <div class="btn-group dropdown">
-        <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name, group = g.Name, logLevels = Model.CommaJoinedSelectedLogLevels() })" class="btn btn-xs @btnClass">
+        <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name, group = g.Name, logLevels = Model.CommaJoinedSelectedLogLevels(), similarHost = Model.SimilarHost, similarUrl = Model.SimilarUrl })" class="btn btn-xs @btnClass">
             @g.Name
             @if (app != null)
             {
@@ -36,7 +36,7 @@
             @foreach (var a in g.Applications)
                 {
                 <li class="@(Model.Log?.Name == a.Name || g.Applications.Count == 1 ? " active" : null)">
-                    <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name, group = g.Name, log = a.Name, logLevels = Model.CommaJoinedSelectedLogLevels()})">
+                    <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name, group = g.Name, log = a.Name, logLevels = Model.CommaJoinedSelectedLogLevels(), similarHost = Model.SimilarHost, similarUrl = Model.SimilarUrl })">
                         @a.Name
                         <span class="badge js-exception-total" data-name="@g.Name-@a.Name">@a.ExceptionCount.ToComma()</span>
                     </a>

--- a/Opserver/Views/Exceptions/Exceptions.cshtml
+++ b/Opserver/Views/Exceptions/Exceptions.cshtml
@@ -27,7 +27,9 @@
                 enablePreviews: @Current.Settings.Exceptions.EnablePreviews.ToJson(),
                 showDeleted: @Model.ShowDeleted.ToJson(),
                 search: @Model.Search.ToJson(),
-                logLevels: '@Model.CommaJoinedSelectedLogLevels()'
+                logLevels: '@Model.CommaJoinedSelectedLogLevels()',
+                similarHost: '@Model.SimilarHost',
+                similarUrl: '@Model.SimilarUrl'
             });
         });
     </script>


### PR DESCRIPTION
### Summary
* Implemented host and url filter
* Both filters work by matching against the db with 'LIKE %value%', that is any string that contains the value the user has entered
* Fixed a bug I introduced on the last commit on the query builder, now the ORs of loglevels are wrapped between parenthesis.