### PR TITLE
Implement Url and Host filter

### DIFF
--- a/src/Opserver.Core/Data/Exceptions/ExceptionStore.cs
+++ b/src/Opserver.Core/Data/Exceptions/ExceptionStore.cs
@@ -172,6 +172,8 @@ Select ApplicationName as Name,
             public ExceptionSorts Sort { get; set; }
             public Guid? Id { get; set; }
             public HashSet<ExceptionLogLevel> LogLevels { get; set; } = new HashSet<ExceptionLogLevel>();
+            public string Host { get; set; }
+            public string Url { get; set; }
 
             public override int GetHashCode()
             {
@@ -187,6 +189,8 @@ Select ApplicationName as Name,
                 hashCode = (hashCode * -1521134295) + EqualityComparer<Guid?>.Default.GetHashCode(StartAt);
                 hashCode = (hashCode * -1521134295) + EqualityComparer<Guid?>.Default.GetHashCode(Id);
                 hashCode = (hashCode * -1521134295) + EqualityComparer<HashSet<ExceptionLogLevel>>.Default.GetHashCode(LogLevels);
+                hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(Host);
+                hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(Url);
                 return (hashCode * -1521134295) + Sort.GetHashCode();
             }
         }
@@ -265,6 +269,14 @@ Select e.Id,
             {
                 AddClause("(" + string.Join(" OR ", search.LogLevels.Select(logLevel => "LogLevel = " + (short)logLevel)) + ")");
             }
+            if (search.Host.HasValue())
+            {
+                AddClause("Host Like @Host");
+            }
+            if (search.Url.HasValue())
+            {
+                AddClause("Url Like @Url");
+            }
             if (mode == QueryMode.Delete)
             {
                 AddClause("IsProtected = 0");
@@ -300,7 +312,9 @@ Select e.Id,
                 query = "%" + search.SearchQuery + "%",
                 search.StartAt,
                 search.Count,
-                search.Id
+                search.Id,
+                search.Host,
+                search.Url
             });
         }
 

--- a/src/Opserver.Core/Data/Exceptions/ExceptionStore.cs
+++ b/src/Opserver.Core/Data/Exceptions/ExceptionStore.cs
@@ -313,8 +313,8 @@ Select e.Id,
                 search.StartAt,
                 search.Count,
                 search.Id,
-                search.Host,
-                search.Url
+                Host = search.Host?.Replace('*', '%'),
+                Url = search.Url?.Replace('*', '%')
             });
         }
 

--- a/src/Opserver.Web/ContentSource/js/Scripts.js
+++ b/src/Opserver.Web/ContentSource/js/Scripts.js
@@ -1447,12 +1447,20 @@ Status.Exceptions = (function () {
             .get();
     }
 
+    function getSanitzedInputValue(inputId) {
+        let inputValue = $(inputId).val();
+        if (inputValue === null) {
+            return '';
+        }
+        return inputValue.trim();
+    }
+
     function getHostFilterValue() {
-        return $('#hostFilterInput').val();
+        return getSanitzedInputValue('#hostFilterInput');
     }
 
     function getUrlFilterValue() {
-        return $('#urlFilterInput').val();
+        return getSanitzedInputValue('#urlFilterInput');
     }
 
     $(document).on('submit', '#exceptionFiltersForm', function (event) {
@@ -1464,13 +1472,13 @@ Status.Exceptions = (function () {
             searchParams.set("logLevels", selectedLogLevels.join(','));
         }
         let host = getHostFilterValue();
-        if (host === null || host === '') {
+        if (host === '') {
             searchParams.delete("host");
         } else {
             searchParams.set("host", host);
         }
         let url = getUrlFilterValue();
-        if (url === null || url === '') {
+        if (url === '') {
             searchParams.delete("url");
         } else {
             searchParams.set("url", url);
@@ -1483,6 +1491,10 @@ Status.Exceptions = (function () {
             location.href = urlWithoutSearchParams + '?' + searchParams.toString();
         }
         event.preventDefault();
+    });
+
+    $(document).ready(function () {
+        $('[data-toggle="tooltip"]').tooltip();
     });
 
     return {

--- a/src/Opserver.Web/ContentSource/js/Scripts.js
+++ b/src/Opserver.Web/ContentSource/js/Scripts.js
@@ -1054,7 +1054,9 @@ Status.Exceptions = (function () {
             group: options.group,
             log: options.log,
             sort: options.sort,
-            logLevels: options.logLevels
+            logLevels: options.logLevels,
+            host: options.host,
+            url: options.url
         };
 
         // TODO: Set refresh params
@@ -1445,12 +1447,41 @@ Status.Exceptions = (function () {
             .get();
     }
 
+    function getHostFilterValue() {
+        return $('#hostFilterInput').val();
+    }
+
+    function getUrlFilterValue() {
+        return $('#urlFilterInput').val();
+    }
+
     $(document).on('submit', '#exceptionFiltersForm', function (event) {
-        let selectedLogLevels = getSelectedLogLevels();
         let searchParams = new URLSearchParams(window.location.search);
-        searchParams.set("logLevels", selectedLogLevels.join(','));
+        let selectedLogLevels = getSelectedLogLevels();
+        if (selectedLogLevels.length === 0) {
+            searchParams.delete("logLevels");
+        } else {
+            searchParams.set("logLevels", selectedLogLevels.join(','));
+        }
+        let host = getHostFilterValue();
+        if (host === null || host === '') {
+            searchParams.delete("host");
+        } else {
+            searchParams.set("host", host);
+        }
+        let url = getUrlFilterValue();
+        if (url === null || url === '') {
+            searchParams.delete("url");
+        } else {
+            searchParams.set("url", url);
+        }
+
         let urlWithoutSearchParams = window.location.href.split('?')[0];
-        location.href = urlWithoutSearchParams + '?' + searchParams.toString();
+        if (searchParams === null || searchParams.toString() === '') {
+            location.href = urlWithoutSearchParams;
+        } else {
+            location.href = urlWithoutSearchParams + '?' + searchParams.toString();
+        }
         event.preventDefault();
     });
 

--- a/src/Opserver.Web/Controllers/ExceptionsController.cs
+++ b/src/Opserver.Web/Controllers/ExceptionsController.cs
@@ -44,8 +44,8 @@ namespace Opserver.Controllers
             CurrentSimilarId = GetParam("similar").HasValue() && Guid.TryParse(GetParam("similar"), out var similarGuid) ? similarGuid : (Guid?)null;
             Enum.TryParse(GetParam("sort"), out CurrentSort);
             CurrentExceptionLogLevels = GetCurrentExceptionLogLevels();
-            CurrentHost = GetParam("host");
-            CurrentUrl = GetParam("url");
+            CurrentHost = GetParam("host")?.Trim();
+            CurrentUrl = GetParam("url")?.Trim();
 
             if (CurrentLog.HasValue())
             {

--- a/src/Opserver.Web/Controllers/ExceptionsController.cs
+++ b/src/Opserver.Web/Controllers/ExceptionsController.cs
@@ -30,6 +30,8 @@ namespace Opserver.Controllers
         private ExceptionSorts CurrentSort;
         private HashSet<ExceptionLogLevel> CurrentExceptionLogLevels;
         private static readonly HashSet<ExceptionLogLevel> DefaultExceptionLogLevels = new HashSet<ExceptionLogLevel>() { ExceptionLogLevel.Critical, ExceptionLogLevel.Error };
+        private string CurrentHost;
+        private string CurrentUrl;
 
         public ExceptionsController(ExceptionsModule module, IOptions<OpserverSettings> settings) : base(module, settings) { }
 
@@ -42,6 +44,8 @@ namespace Opserver.Controllers
             CurrentSimilarId = GetParam("similar").HasValue() && Guid.TryParse(GetParam("similar"), out var similarGuid) ? similarGuid : (Guid?)null;
             Enum.TryParse(GetParam("sort"), out CurrentSort);
             CurrentExceptionLogLevels = GetCurrentExceptionLogLevels();
+            CurrentHost = GetParam("host");
+            CurrentUrl = GetParam("url");
 
             if (CurrentLog.HasValue())
             {
@@ -77,7 +81,9 @@ namespace Opserver.Controllers
                 Log = CurrentLog,
                 Sort = CurrentSort,
                 Id = CurrentId,
-                LogLevels = CurrentExceptionLogLevels
+                LogLevels = CurrentExceptionLogLevels,
+                Host = CurrentHost,
+                Url = CurrentUrl
             };
 
             if (GetParam("q").HasValue())
@@ -138,7 +144,9 @@ namespace Opserver.Controllers
                 Log = log,
                 Sort = CurrentSort,
                 Errors = errors,
-                SelectedLogLevels = CurrentExceptionLogLevels
+                SelectedLogLevels = CurrentExceptionLogLevels,
+                Host = CurrentHost,
+                Url = CurrentUrl
             };
         }
 

--- a/src/Opserver.Web/Views/Exceptions/Exceptions.Filters.cshtml
+++ b/src/Opserver.Web/Views/Exceptions/Exceptions.Filters.cshtml
@@ -1,6 +1,12 @@
 ﻿@model ExceptionsModel
 
 <form class="navbar-form" id="exceptionFiltersForm">
+     <div class="form-group">
+        <input id="hostFilterInput" type="text" class="form-control input-sm" placeholder="Filter by Host" value="@(Model.Host == null ? "" : Model.Host)">
+    </div>
+    <div class="form-group">
+        <input id="urlFilterInput" type="text" class="form-control input-sm" placeholder="Filter by Url" value="@(Model.Url == null ? "" : Model.Url)">
+    </div>
     <div class="form-group">
         <div class="dropdown">
             <button class="btn btn-xs btn-default dropdown-toggle" type="button" id="logLevelDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">

--- a/src/Opserver.Web/Views/Exceptions/Exceptions.Filters.cshtml
+++ b/src/Opserver.Web/Views/Exceptions/Exceptions.Filters.cshtml
@@ -1,10 +1,15 @@
 ﻿@model ExceptionsModel
 
 <form class="navbar-form" id="exceptionFiltersForm">
-     <div class="form-group">
+    @{
+        string tooltipMessage = "This filter supports wildcards by using '*'. They may slow down queries, leading wildcards are usually slower than trailing ones.";
+    }
+    <div class="form-group">
+        <i class="fa fa-question-circle" aria-hidden="true" data-toggle="tooltip" title="@tooltipMessage"></i>
         <input id="hostFilterInput" type="text" class="form-control input-sm" placeholder="Filter by Host" value="@(Model.Host == null ? "" : Model.Host)">
     </div>
     <div class="form-group">
+        <i class="fa fa-question-circle" aria-hidden="true" data-toggle="tooltip" title="@tooltipMessage"></i>
         <input id="urlFilterInput" type="text" class="form-control input-sm" placeholder="Filter by Url" value="@(Model.Url == null ? "" : Model.Url)">
     </div>
     <div class="form-group">

--- a/src/Opserver.Web/Views/Exceptions/Exceptions.Model.cs
+++ b/src/Opserver.Web/Views/Exceptions/Exceptions.Model.cs
@@ -26,6 +26,8 @@ namespace Opserver.Views.Exceptions
 
         public List<ExceptionLogLevel> LogLevels = new List<ExceptionLogLevel>() { ExceptionLogLevel.Critical, ExceptionLogLevel.Error, ExceptionLogLevel.Warning, ExceptionLogLevel.Info, ExceptionLogLevel.Debug, ExceptionLogLevel.Trace };
         public HashSet<ExceptionLogLevel> SelectedLogLevels { get; set; } = new HashSet<ExceptionLogLevel>();
+        public string Host { get; set; }
+        public string Url { get; set; }
 
         public bool ShowAll => Group == null && Log == null;
         private int? _shownCount;

--- a/src/Opserver.Web/Views/Exceptions/Exceptions.Navigation.cshtml
+++ b/src/Opserver.Web/Views/Exceptions/Exceptions.Navigation.cshtml
@@ -1,7 +1,7 @@
 ﻿@model ExceptionsModel
 @if (Model.Groups.Count > 1)
 {
-    <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name, logLevels = Model.CommaJoinedSelectedLogLevels() })" title="View All" class="btn btn-xs@(Model.ShowAll ? " btn-primary" : null)">View All</a>
+    <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name, logLevels = Model.CommaJoinedSelectedLogLevels(), host = Model.Host, url = Model.Url })" title="View All" class="btn btn-xs@(Model.ShowAll ? " btn-primary" : null)">View All</a>
 }
 @foreach (var g in Model.Groups)
 {
@@ -13,7 +13,7 @@
     var btnClass = active ? "btn-primary" : "";
     var app = Model.Log != null && g.Applications.Contains(Model.Log) ? Model.Log : null;
     <div class="btn-group dropdown">
-        <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name, group = g.Name, logLevels = Model.CommaJoinedSelectedLogLevels() })" class="btn btn-xs @btnClass">
+        <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name, group = g.Name, logLevels = Model.CommaJoinedSelectedLogLevels(), host = Model.Host, url = Model.Url })" class="btn btn-xs @btnClass">
             @g.Name
             @if (app != null)
             {
@@ -32,7 +32,7 @@
             @foreach (var a in g.Applications)
                 {
                 <li class="@(Model.Log?.Name == a.Name || g.Applications.Count == 1 ? " active" : null)">
-                    <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name, group = g.Name, log = a.Name, logLevels = Model.CommaJoinedSelectedLogLevels() })">
+                    <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name, group = g.Name, log = a.Name, logLevels = Model.CommaJoinedSelectedLogLevels(), host = Model.Host, url = Model.Url })">
                         @a.Name
                         <span class="badge js-exception-total" data-name="@g.Name-@a.Name">@a.ExceptionCount.ToComma()</span>
                     </a>

--- a/src/Opserver.Web/Views/Exceptions/Exceptions.cshtml
+++ b/src/Opserver.Web/Views/Exceptions/Exceptions.cshtml
@@ -25,7 +25,9 @@
                 enablePreviews: @Module.Settings.EnablePreviews.ToJson(),
                 showDeleted: @Model.ShowDeleted.ToJson(),
                 search: @Model.Search.ToJson(),
-                logLevels: '@Model.CommaJoinedSelectedLogLevels()'
+                logLevels: '@Model.CommaJoinedSelectedLogLevels()',
+                host: '@Model.Host',
+                url: '@Model.Url'
             });
         });
     </script>


### PR DESCRIPTION
### Summary
* Implemented host and url filter
* Both filters work by matching against the db with 'LIKE value'. On the previous PR I was using 'LIKE %value%', but @AaronBertrand  suggested this could be 'LIKE value' and provide the user with the ability to enter a wildcard. Still, I'd like to get feedback on this approach,
  * The user can enter a string like "www.stackoverflow.com" or "%stackoverflow.com", "www.stackoverflow%" or "%stackoverflow"%. SQL engine should optimize the first example to a simple '=' equality match.
